### PR TITLE
Fix compile error in GNU 7.5.0

### DIFF
--- a/src/modules/battery.cc
+++ b/src/modules/battery.cc
@@ -10,6 +10,7 @@ extern "C" {
 #include <algorithm>
 #include <iostream>
 #include <vector>
+#include <cstring>
 
 namespace excalibar {
 


### PR DESCRIPTION
In gcc version 7.5.0 :
```
/home/yuan/excalibar/src/modules/battery.cc:29:10: error: ‘memset’ is not a member of ‘std’
   ::std::memset(buf, 0, sizeof(buf));
```